### PR TITLE
feat: stop recording when AttendiMicrophone is dismissed

### DIFF
--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/AttendiMicrophone.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/AttendiMicrophone.swift
@@ -264,6 +264,8 @@ public struct AttendiMicrophone: View {
             plugins.forEach { $0.activate(self) }
         }
         .onDisappear {
+            recorder.stopRecording()
+            
             plugins.forEach { $0.deactivate(self) }
         }
     }


### PR DESCRIPTION
Previously, the tap was still installed on the audio engine even after the AttendiMicrophone was dismissed from the view.