### PR TITLE
feat: handle audio interruptions

### DIFF
--- a/Sources/AttendiSpeechService/Core/Audio/AttendiAudioPlayerDelegate.swift
+++ b/Sources/AttendiSpeechService/Core/Audio/AttendiAudioPlayerDelegate.swift
@@ -36,9 +36,9 @@ public class AttendiAudioPlayerDelegate: NSObject, AVAudioPlayerDelegate {
         // We don't need to set the category if we can already playback
         if oldCategory != .playAndRecord && oldCategory != .playback {
             do {
-                try session.setCategory(.playback, options: .defaultToSpeaker)
+                try session.setCategory(.playback)
             } catch {
-                print("Setting audio session category to `playAndRecord` failed.")
+                print("Setting audio session category to `playback` failed.")
             }
         }
         


### PR DESCRIPTION
Audio interruptions occur for instance when the device receives a call, or SIri is activated. For now, we decide to always pause recording when the interruption begins and continue recording when the interruption is ended.