### PR TITLE
feat: add triggerError plugin API

### DIFF
--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/AttendiMicrophone.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/AttendiMicrophone.swift
@@ -297,12 +297,10 @@ public struct AttendiMicrophone: View {
                         do {
                             try recorder.resumeRecording()
                         } catch {
-                            for callback in callbacks.errorCallbacks.values {
-                                Task {
-                                    await callback(.general(message: "Er is iets misgegaan."))
-                                }
+                            Task {
+                                await triggerError(.general(message: "Er is iets misgegaan."))
                             }
-                            
+
                             reset()
                         }
                     }
@@ -365,12 +363,9 @@ public struct AttendiMicrophone: View {
         requestMicrophonePermission { allowed in
             if !allowed {
                 Task {
-                    do {
-                        for callback in self.callbacks.errorCallbacks.values {
-                            await callback(.noPermission)
-                        }
-                    }
+                    await triggerError(.noPermission)
                 }
+                
                 return
             }
             
@@ -399,9 +394,7 @@ public struct AttendiMicrophone: View {
                     } catch {
                         reset()
                         
-                        for callback in self.callbacks.errorCallbacks.values {
-                            await callback(.cantStartRecording)
-                        }
+                        await triggerError(.cantStartRecording)
                     }
                 }
             }
@@ -494,7 +487,15 @@ public struct AttendiMicrophone: View {
         recorder.clearBuffer()
         recorder.stopRecording()
     }
-        
+    
+    /// [PLUGIN API]
+    /// Trigger an error by calling all registered error callbacks.
+    public func triggerError(_ error: AttendiMicrophone.Errors) async {
+        for callback in self.callbacks.errorCallbacks.values {
+            await callback(error)
+        }
+    }
+
     // MARK: ============= Options menu =============
     
     @State var isOptionsMenuVisible: Bool = false

--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/Plugins/AttendiTranscribePlugin.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/Plugins/AttendiTranscribePlugin.swift
@@ -42,9 +42,7 @@ public class AttendiTranscribePlugin: AttendiMicrophonePlugin {
                 mic.onEvent("attendi-transcribe", transcript)
                 mic.onResult(transcript)
             case .failure(let error):
-                for callback in mic.callbacks.errorCallbacks.values {
-                    await callback(.general(message: "Kon de audio niet opsturen"))
-                }
+                await mic.triggerError(.general(message: "Kon de audio niet opsturen"))
                 print("Error: \(error)")
             }
         }

--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/Plugins/Private/AttendiAssistantPlugin.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/Plugins/Private/AttendiAssistantPlugin.swift
@@ -35,9 +35,7 @@ final public class AttendiAssistantPlugin: AttendiMicrophonePlugin {
                 mic.onResult(transcript)
                 self.goBackToNormalState(mic)
             case .failure(let error):
-                for callback in mic.callbacks.errorCallbacks.values {
-                    await callback(.general(message: "Kon de audio niet opsturen"))
-                }
+                await mic.triggerError(.general(message: "Kon de audio niet opsturen"))
                 print("Error: \(error)")
             }
         }


### PR DESCRIPTION
The callbacks members in AttendiMicrophone.callbacks are private. However, it may still be necessary to trigger an error from the plugins. To allow for this, we introduce the `triggerError` API. When a plugin or client wants to call the registered error callbacks, they can run `mic.triggerError(error)`.