### PR TITLE
feat: allow more granular color theming

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -77,7 +77,8 @@ struct TwoMicrophonesScreen: View {
                         .frame(height: 36)
                     
                     AttendiMicrophone(
-                        microphoneModifier: AttendiMicrophoneModifier(size: 56, color: pinkColor),
+                        size: 56,
+                        colors: AttendiMicrophone.Colors(baseColor: pinkColor),
                         plugins: [
                             AttendiErrorPlugin(),
                             AttendiTranscribePlugin(apiConfig: apiConfig),
@@ -102,7 +103,8 @@ struct TwoMicrophonesScreen: View {
                     
                     HStack {
                         AttendiMicrophone(
-                            microphoneModifier: AttendiMicrophoneModifier(size: 56, color: pinkColor),
+                            size: 56,
+                            colors: AttendiMicrophone.Colors(baseColor: pinkColor),
                             plugins: [
                                 AttendiErrorPlugin(),
                                 AttendiTranscribePlugin(apiConfig: apiConfig),
@@ -198,7 +200,13 @@ struct HoveringMicrophoneScreen: View {
                 HStack {
                     Spacer()
                     AttendiMicrophone(
-                        microphoneModifier: AttendiMicrophoneModifier(size: 64, color: pinkColor),
+                        size: 64,
+                        colors: AttendiMicrophone.Colors(
+                            inactiveBackgroundColor: pinkColor,
+                            inactiveForegroundColor: Color.white,
+                            activeBackgroundColor: pinkColor,
+                            activeForegroundColor: Color.white
+                        ),
                         plugins: [
                             AttendiErrorPlugin(),
                             AttendiTranscribePlugin(apiConfig: apiConfig),
@@ -221,8 +229,6 @@ struct HoveringMicrophoneScreen: View {
                             self.microphoneUIState = uiState
                         }
                     }
-                    .background(Color.white.clipShape(Circle()))
-                    .overlay(Circle().stroke(pinkColor))
                     .padding(16)
                 }
             }

--- a/README.md
+++ b/README.md
@@ -65,9 +65,22 @@ import AttendiSpeechService
 // within some SwiftUI view
 
 AttendiMicrophone(
-    // Change aspects of the microphone's appearance, such as size and color,
-    // using the `microphoneModifier` parameter
-    microphoneModifier: AttendiMicrophoneModifier(size: 56, color: Color.red),
+    // Sets the width and height of the microphone.
+    size: 60,
+    // Specify detailed color theme. The mic is considered active when it is recording
+    // or processing.
+    colors: AttendiMicrophone.Colors(
+        inactiveBackgroundColor: pinkColor,
+        inactiveForegroundColor: Color.white,
+        activeBackgroundColor: pinkColor,
+        activeForegroundColor: Color.white
+    ),
+    // or create a color theme from one color
+    // colors: AttendiMicrophone.Colors(baseColor: Color.Red),
+    //
+    // If not set, the component will have a circular shape. Otherwise, uses a
+    // rounded corner shape with this corner radius.
+    cornerRadius: 20,
     // Add plugins if necessary. These extend the functionality of the microphone component.
     plugins: [
         // Tells microphone what to do when an error occurs.
@@ -104,17 +117,13 @@ The `onAppear` callback is useful when wanting to add some functionality to the 
 
 AttendiMicrophone(
     // ...
+)
     onAppear: { mic in
         mic.callbacks.onUIState { uiState in
             self.microphoneUIState = uiState
         }
     }
-)
 ```
-
-## Styling
-
-The microphone component can be styled using the `microphoneModifier` parameter. See the `AttendiMicrophoneModifier`'s Swift documentation for more details.
 
 ## Creating a plugin
 

--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/AttendiMicrophone+Modifiers.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/AttendiMicrophone+Modifiers.swift
@@ -17,14 +17,6 @@ import SwiftUI
 // View Modifiers
 extension AttendiMicrophone {
     @discardableResult
-    public func variant(_ variant: AttendiMicrophone.Variant) -> AttendiMicrophone {
-        let component = self
-        
-        component.settings.variant = variant
-        return component
-    }
-    
-    @discardableResult
     public func showOptions(_ variant: AttendiMicrophone.OptionsVariant = .normal) -> AttendiMicrophone {
         let component = self
         

--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/OptionsMenu/Views/ReportingMethodView/ReportingMethodView.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/OptionsMenu/Views/ReportingMethodView/ReportingMethodView.swift
@@ -55,20 +55,20 @@ struct ReportingMethodView: View {
 
                             VStack(spacing: 20) {
                                 AttendiMicrophone(
-                                    microphoneModifier: AttendiMicrophoneModifier(size: 60),
+                                    size: 60,
                                     plugins: [
                                         AttendiTranscribePlugin(apiConfig: apiConfig)
                                     ]
                                 )
-                                .variant(.white)
-                                .background(settings.color)
+//                                .variant(.white)
+//                                .background(settings.color)
                                 .cornerRadius(100)
 
                                 CompleteButton
                                     .padding(20)
-                                    .overlay(
-                                        Circle().stroke(settings.color, lineWidth: 2)
-                                    )
+//                                    .overlay(
+//                                        Circle().stroke(settings.color, lineWidth: 2)
+//                                    )
                             }
                             .padding(.leading, 20)
                         }
@@ -109,14 +109,14 @@ struct ReportingMethodView: View {
                         Spacer()
 
                         AttendiMicrophone(
-                            microphoneModifier: AttendiMicrophoneModifier(size: 60),
+                            size: 60,
                             plugins: [
                                 AttendiTranscribePlugin(apiConfig: apiConfig)
                             ]
                         )
                         // TODO: change 'variant' type
-                        .variant(.white)
-                        .background(settings.color)
+//                        .variant(.white)
+//                        .background(settings.color)
                         .cornerRadius(100)
 
                         Spacer()
@@ -124,9 +124,9 @@ struct ReportingMethodView: View {
                         CompleteButton
                             .padding(15)
                             .frame(minWidth: 0, maxWidth: .infinity)
-                            .overlay(
-                                Circle().stroke(settings.color, lineWidth: 2)
-                            )
+//                            .overlay(
+//                                Circle().stroke(settings.color, lineWidth: 2)
+//                            )
                     }
                     .padding(.top, 20)
                     .padding(.bottom, 20)
@@ -206,7 +206,7 @@ struct ReportingMethodView: View {
                     .frame(width: 15, height: 15)
                     .opacity(submitting ? 1 : 0)
                 Image(systemName: "checkmark")
-                    .foregroundColor(settings.color)
+//                    .foregroundColor(settings.color)
                     .font(.system(size: 15, weight: .bold))
                     .opacity(submitting ? 0 : 1)
             }

--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/OptionsMenu/Views/ReportingMethodView/ReportingStepView.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/OptionsMenu/Views/ReportingMethodView/ReportingStepView.swift
@@ -27,13 +27,13 @@ struct ReportingStepView: View {
         Text(step)
             .font(.title)
             .frame(width: 60, height: 60)
-            .background(hasValue ? settings.color.opacity(0.1) : .clear)
+//            .background(hasValue ? settings.color.opacity(0.1) : .clear)
             .cornerRadius(100)
             .foregroundColor(colorScheme == .dark ? .white : .black)
-            .overlay(
-                Circle()
-                    .stroke(activeIndex == index ? settings.color : Color(.systemGray3), lineWidth: 2)
-            )
+//            .overlay(
+//                Circle()
+//                    .stroke(activeIndex == index ? settings.color : Color(.systemGray3), lineWidth: 2)
+//            )
     }
 }
 

--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/Plugins/Private/AttendiAssistantPlugin.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/Plugins/Private/AttendiAssistantPlugin.swift
@@ -9,7 +9,7 @@ import SwiftUI
 final public class AttendiAssistantPlugin: AttendiMicrophonePlugin {
     let defaultAssistantColor = Color(hex: "#9747FF")
     
-    var previousColor = Color(hex: "#1C69E8")
+    var previousColor = AttendiMicrophone.Colors(baseColor: Color(hex: "#1C69E8"))
     var previousOptionsIcon: AnyView? = nil
     var previousShowOptions: AttendiMicrophone.OptionsVariant = .normal
     
@@ -57,7 +57,7 @@ final public class AttendiAssistantPlugin: AttendiMicrophonePlugin {
                 icon: Image("assistantWriteMyReport", bundle: .module),
                 action: .button(action: {
                     Task { @MainActor in
-                        self.previousColor = mic.settings.color
+                        self.previousColor = mic.settings.colors
                         self.previousOptionsIcon = mic.settings.customUIIcons["options"]
                         self.previousShowOptions = mic.settings.showOptions
                         
@@ -65,7 +65,7 @@ final public class AttendiAssistantPlugin: AttendiMicrophonePlugin {
                         
                         mic.settings.showOptions = .always
                         
-                        mic.settings.color = color
+                        mic.settings.colors = AttendiMicrophone.Colors(baseColor: color)
                         
                         mic.setOptionsIcon(AnyView(
                             Button(action: {self.goBackToNormalState(mic)} ) {
@@ -91,7 +91,7 @@ final public class AttendiAssistantPlugin: AttendiMicrophonePlugin {
     
     @MainActor private func goBackToNormalState(_ mic: AttendiMicrophone) {
         mic.goBackInActiveAudioTaskHistory()
-        mic.settings.color = self.previousColor
+        mic.settings.colors = self.previousColor
         mic.setOptionsIcon(self.previousOptionsIcon)
         mic.showOptions(self.previousShowOptions)
     }

--- a/Sources/AttendiSpeechService/Core/View+Modifiers.swift
+++ b/Sources/AttendiSpeechService/Core/View+Modifiers.swift
@@ -25,6 +25,11 @@ extension View {
         ModifiedContent(content: self, modifier: CornerRadiusStyle(radius: radius, corners: corners))
     }
     
+    /// Clip to circle if `radius` is `nil`, otherwise use the specified corner radius.
+    func conditionalCornerRadius(_ radius: Double?) -> some View {
+        self.modifier(ConditionalCornerRadius(cornerRadius: radius))
+    }
+
     /// Listen to device rotations.
     func onRotate(perform action: @escaping (UIDeviceOrientation) -> Void) -> some View {
         self.modifier(DeviceRotationViewModifier(action: action))
@@ -42,5 +47,17 @@ struct DeviceRotationViewModifier: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
                 action(UIDevice.current.orientation)
             }
+    }
+}
+
+struct ConditionalCornerRadius: ViewModifier {
+    var cornerRadius: Double?
+
+    func body(content: Content) -> some View {
+        if let radius = cornerRadius {
+            return AnyView(content.cornerRadius(radius))
+        } else {
+            return AnyView(content.clipShape(Circle()))
+        }
     }
 }


### PR DESCRIPTION
Previously, it was only possible to set one color for the microphone component. Now it's possible to specify the foreground and background colors when them microphone is `active` and `inactive.

We also simplify styling the component by removing the `MicrophoneModifier` abstraction. This is a breaking change.