### PR TITLE
fix: empty tooltip for audio permission error

### DIFF
--- a/Sources/AttendiSpeechService/Core/AttendiMicrophone/AttendiMicrophone.swift
+++ b/Sources/AttendiSpeechService/Core/AttendiMicrophone/AttendiMicrophone.swift
@@ -334,8 +334,6 @@ public struct AttendiMicrophone: View {
                 self.audioInterruptionObserver = nil
             }
             
-            print("onDisappear")
-            
             recorder.stopRecording()
             
             plugins.forEach { $0.deactivate(self) }


### PR DESCRIPTION
Somehow the tooltip text is in some cases not updated properly in some instances. We fix this here.