### PR TITLE
Fix AttendiAsyncTranscribePlugin UI update and AsyncTranscribeService Retry mechanism

### DIFF
--- a/AttendiSpeechService/AttendiSpeechService.xcodeproj/project.pbxproj
+++ b/AttendiSpeechService/AttendiSpeechService.xcodeproj/project.pbxproj
@@ -253,7 +253,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.1;
+				MARKETING_VERSION = 0.3.2;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = nl.attendi.AttendiSpeechService;
@@ -293,7 +293,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.1;
+				MARKETING_VERSION = 0.3.2;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = nl.attendi.AttendiSpeechService;

--- a/AttendiSpeechService/AttendiSpeechService/Components/AttendiRecorder/Plugins/AsyncTranscribePlugin/AttendiAsyncTranscribePlugin.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Components/AttendiRecorder/Plugins/AsyncTranscribePlugin/AttendiAsyncTranscribePlugin.swift
@@ -70,7 +70,7 @@ public final class AttendiAsyncTranscribePlugin: AttendiRecorderPlugin {
     ///
     /// Starts sending audio when enough buffered samples are collected.
     public func activate(model: AttendiRecorderModel) async {
-        await model.onStartRecording { [weak self, weak model] in
+        await model.onBeforeStartRecording { [weak self, weak model] in
             guard let self, let model else { return }
             await stateMutex.withLock { [weak self, weak model] in
                 guard let self, let model else { return }

--- a/AttendiSpeechService/AttendiSpeechService/Components/AttendiRecorder/Recorder/AttendiRecorderImpl.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Components/AttendiRecorder/Recorder/AttendiRecorderImpl.swift
@@ -130,16 +130,22 @@ final class AttendiRecorderImpl: AttendiRecorder {
                 await model.callbacks.invokeOnBeforeStartRecording()
 
                 recorderTask = Task {
-                    try await Task.sleep(nanoseconds: delayMilliseconds.milliToNano())
-                    await handleErrors {
-                        try await recorder.startRecording(
-                            audioRecordingConfig: audioRecordingConfig,
-                            onAudio: { audioFrame in
-                                await self.model.callbacks.invokeOnAudioFrame(audioFrame)
-                            }
-                        )
-                        await model.updateState(.recording)
-                        await model.callbacks.invokeOnStartRecording()
+                    try? await startStopMutex.withLock {
+                        if !hasStarted || isReleased {
+                            return
+                        }
+                        
+                        try await Task.sleep(nanoseconds: delayMilliseconds.milliToNano())
+                        await handleErrors {
+                            try await recorder.startRecording(
+                                audioRecordingConfig: audioRecordingConfig,
+                                onAudio: { audioFrame in
+                                    await self.model.callbacks.invokeOnAudioFrame(audioFrame)
+                                }
+                            )
+                            await model.updateState(.recording)
+                            await model.callbacks.invokeOnStartRecording()
+                        }
                     }
                 }
             }

--- a/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/AsyncTranscribeService.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/AsyncTranscribeService.swift
@@ -53,7 +53,7 @@ public enum AsyncTranscribeServiceError: Error, LocalizedError {
     case failedToConnect(message: String)
 
     /// Indicates the connection closed unexpectedly or with an abnormal code.
-    case closedAbnormally(message: String)
+    case closedAbnormally(message: String?)
 
     /// Connection attempt exceeded the allowed timeout.
     case connectTimeout

--- a/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/AttendiAsyncTranscribeServiceFactory.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/AttendiAsyncTranscribeServiceFactory.swift
@@ -7,12 +7,19 @@ public struct AttendiAsyncTranscribeServiceFactory {
     ///
     /// This service manages the WebSocket connection, authentication, and audio streaming.
     ///
-    /// - Parameter apiConfig: Configuration for authentication and endpoint setup.
+    /// - Parameters
+    ///   - apiConfig: Configuration for authentication and endpoint setup.
+    ///   - accessToken: Optional pre-obtained access token. If provided, it will be used directly for authentication
+    ///     instead of requesting a new token from the authentication service.
     /// - Returns: A fully configured instance of `AsyncTranscribeService`.
-    public static func create(apiConfig: AttendiTranscribeAPIConfig) -> AsyncTranscribeService {
+    public static func create(
+        apiConfig: AttendiTranscribeAPIConfig,
+        accessToken: String? = nil
+    ) -> AsyncTranscribeService {
         return AttendiAsyncTranscribeServiceImpl(
             apiConfig: apiConfig,
-            authenticationService: AttendiAuthenticationServiceImpl()
+            authenticationService: AttendiAuthenticationServiceImpl(),
+            accessToken: accessToken
         )
     }
 }

--- a/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/AttendiAsyncTranscribeServiceImpl.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/AttendiAsyncTranscribeServiceImpl.swift
@@ -27,8 +27,8 @@ class AttendiAsyncTranscribeServiceImpl: BaseAsyncTranscribeService {
 
     private let apiConfig: AttendiTranscribeAPIConfig
     private let authenticationService: AttendiAuthenticationService
-    private let accessToken: String?
-    
+    private var accessToken: String?
+
     init(
         apiConfig: AttendiTranscribeAPIConfig,
         authenticationService: AttendiAuthenticationService,
@@ -47,6 +47,7 @@ class AttendiAsyncTranscribeServiceImpl: BaseAsyncTranscribeService {
         } else {
             token = try await authenticationService.authenticate(apiConfig: apiConfig)
         }
+        accessToken = token
         return try createAttendiWebSocketRequest(accessToken: token)
     }
     

--- a/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/BaseAsyncTranscribeService.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/BaseAsyncTranscribeService.swift
@@ -159,6 +159,7 @@ class BaseAsyncTranscribeService: AsyncTranscribeService {
         } catch {
             if retryCount == 0 {
                 listener.onError(.unknown(message: error.localizedDescription))
+                handleSocketClosed()
             } else {
                 try await connectSocket(
                     listener: listener,
@@ -172,37 +173,48 @@ class BaseAsyncTranscribeService: AsyncTranscribeService {
     }
 
     private func connectSocket(request: URLRequest) async throws {
-        /// Use URLSession for WebSocket connection with custom headers.
-        let session = URLSession(configuration: .default)
-        let webSocketTask = session.webSocketTask(with: request)
-        self.socket = webSocketTask
-
         return try await withCheckedThrowingContinuation { [weak self] continuation in
             guard let self else {
                 continuation.resume()
                 return
             }
 
+            /// Use URLSession for WebSocket connection with custom headers.
+            let socketSessionStatusBridge = WebSocketSessionStatusBridge(
+                onOpen: { [weak self] in
+                    guard let self else { return }
+
+                    /// Send initial configuration message if provided.
+                    if let openMessage = getOpenMessage() {
+                        Task { [weak self] in
+                            guard let self else { return }
+                            await send(message: openMessage)
+                        }
+                    }
+
+                    isConnected = true
+                    listener?.onOpen()
+                    continuation.resume()
+                },
+                onClose: { [weak self] closeCode, reason in
+                    guard let self else { return }
+                    if closeCode != URLSessionWebSocketTask.CloseCode.normalClosure {
+                        listener?.onError(AsyncTranscribeServiceError.closedAbnormally(message: reason))
+                    }
+                    handleSocketClosed()
+
+                }
+            )
+            let session = URLSession(configuration: .default, delegate: socketSessionStatusBridge, delegateQueue: nil)
+            let webSocketTask = session.webSocketTask(with: request)
+            self.socket = webSocketTask
             webSocketTask.resume()
 
-            /// Start receiving messages.
-            receiveMessage()
-
-            /// Send initial configuration message if provided.
-            if let openMessage = getOpenMessage() {
-                Task { [weak self] in
-                    guard let self else { return }
-                    await send(message: openMessage)
-                }
-            }
-
-            isConnected = true
-            listener?.onOpen()
-            continuation.resume()
+            receiveMessage(continuation: continuation)
         }
     }
 
-    private func receiveMessage() {
+    private func receiveMessage(continuation: CheckedContinuation<(), any Error>) {
         socket?.receive { [weak self] result in
             guard let self else { return }
             switch result {
@@ -215,13 +227,13 @@ class BaseAsyncTranscribeService: AsyncTranscribeService {
                 }
 
                 /// Continue receiving messages.
-                receiveMessage()
+                receiveMessage(continuation: continuation)
 
             case .failure(let error):
-                if !isDisconnecting {
-                    listener?.onError(.unknown(message: error.localizedDescription))
+                /// This case is when authentication succeeds, but the socket fails to connect.
+                if !isConnected && socket != nil {
+                    continuation.resume(throwing: error)
                 }
-                handleSocketClosed()
             }
         }
     }
@@ -266,7 +278,8 @@ class BaseAsyncTranscribeService: AsyncTranscribeService {
         while socket != nil {
             try? await Task.sleep(nanoseconds: Constants.serverCloseSocketIntervalCheckMilliseconds.milliToNano())
 
-            if DispatchTime.now().uptimeNanoseconds - startTime.uptimeNanoseconds > Constants.serverCloseSocketTimeoutMilliseconds.milliToNano() {
+            let elapsedTime = DispatchTime.now().uptimeNanoseconds - startTime.uptimeNanoseconds
+            if elapsedTime > Constants.serverCloseSocketTimeoutMilliseconds.milliToNano() {
                 return false /// Timeout reached.
             }
         }

--- a/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/WebSocketSessionStatusBridge.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/WebSocketSessionStatusBridge.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A lightweight delegate bridge for observing WebSocket connection state.
+///
+/// `WebSocketSessionStatusBridge` conforms to `URLSessionWebSocketDelegate` and
+/// exposes closure callbacks (`onOpen` and `onClose`).
+final class WebSocketSessionStatusBridge: NSObject, URLSessionWebSocketDelegate {
+
+    private let onOpen: () -> Void
+    private let onClose: (URLSessionWebSocketTask.CloseCode, String?) -> Void
+
+    /// Creates a new bridge with closures for connection lifecycle events.
+    ///
+    /// - Parameters:
+    ///   - onOpen: Called when the WebSocket connection is successfully established.
+    ///   - onClose: Called when the WebSocket connection is closed, with the close code
+    ///     and an optional textual reason (decoded from `Data` if provided).
+    init(
+        onOpen: @escaping () -> Void,
+        onClose: @escaping (URLSessionWebSocketTask.CloseCode, String?) -> Void
+    ) {
+        self.onOpen = onOpen
+        self.onClose = onClose
+    }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        onOpen()
+    }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith code: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        var reasonString: String? = nil
+        if let reason, !reason.isEmpty {
+            reasonString = String(data: reason, encoding: .utf8)
+            ?? reason.map { String(format: "%02x", $0) }.joined()
+        }
+        onClose(code, reasonString)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2 - 2025-09-29]
+### Changed
+- `AttendiAsyncTranscribePlugin` now connects to the WebSocket in `onBeforeStartRecording` instead of `onStartRecording`.
+  This ensures that the `AttendiMicrophone` component remains in the loading state until the WebSocket connection is fully established, improving UI consistency and user feedback.
+
+### Fixed
+- Race condition issue where stopping a recording and immediately starting a new one could leave the `AttendiMicrophone` in an incorrect UI state.
+- `AsyncTranscribeService` retry mechanism where the retry logic would not continue properly after a successful retry attempt.
+
 ## [0.3.1 - 2025-08-12]
 ### Changed
 - Renamed `AttendiMicrophone` API methods


### PR DESCRIPTION
## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [X] Linked to an open issue

## Description
### Changed
- `AttendiAsyncTranscribePlugin` now connects to the WebSocket in `onBeforeStartRecording` instead of `onStartRecording`.
  This ensures that the `AttendiMicrophone` component remains in the loading state until the WebSocket connection is fully established, improving UI consistency and user feedback.

### Fixed
- Race condition issue where stopping a recording and immediately starting a new one could leave the `AttendiMicrophone` in an incorrect UI state.
- `AsyncTranscribeService` retry mechanism where the retry logic would not continue properly after a successful retry attempt.