### PR TITLE
Fix - improve recorder's resources release process

### DIFF
--- a/AttendiSpeechService/AttendiSpeechService/Components/AttendiMicrophone/Microphone/AttendiMicrophoneViewModel.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Components/AttendiMicrophone/Microphone/AttendiMicrophoneViewModel.swift
@@ -149,14 +149,13 @@ final class AttendiMicrophoneViewModel: ObservableObject {
         }
     }
 
-    /// Cleans up plugins and recorder when ViewModel is deallocated.
+    /// Deactivates the microphone's own plugins when the ViewModel is deallocated.
     deinit {
         let recorder = self.recorder
         let microphoneVolumeFeedbackPlugin = self.microphoneVolumeFeedbackPlugin
 
         Task.detached(priority: .background) {
             await microphoneVolumeFeedbackPlugin?.deactivate(model: recorder.model)
-            await recorder.release()
         }
     }
 }

--- a/AttendiSpeechService/AttendiSpeechService/Components/AttendiRecorder/Recorder/AttendiRecorder.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Components/AttendiRecorder/Recorder/AttendiRecorder.swift
@@ -9,6 +9,14 @@ import Combine
 ///
 /// The `release()` method **must be called** when the recorder is no longer needed,
 /// to avoid resource leaks including audio session locks, memory consumption, or thread retention.
+///
+/// - Important: Whoever instantiates a recorder is always responsible for cleaning up its
+///   resources itself by calling `release()` when the recorder is no longer needed. Components
+///   that merely receive a recorder — such as `AttendiMicrophone` — do **not** release it, since
+///   they do not own its lifecycle. Releasing a recorder you did not create risks tearing it down
+///   while its owner still intends to use it, or double-releasing it. Typically the owner is the
+///   screen or ViewModel that created the recorder, which releases it from `deinit` (or, for a
+///   recorder owned directly by a SwiftUI `View`, from `.onDisappear`).
 public protocol AttendiRecorder {
 
     /// The core model containing callbacks and state update hooks used to drive plugin behavior.

--- a/AttendiSpeechServiceExample/AttendiSpeechServiceExample/Examples/Screens/OneMicrophoneSyncScreen/OneMicrophoneSyncScreenView.swift
+++ b/AttendiSpeechServiceExample/AttendiSpeechServiceExample/Examples/Screens/OneMicrophoneSyncScreen/OneMicrophoneSyncScreenView.swift
@@ -52,6 +52,14 @@ struct OneMicrophoneSyncScreenView: View {
                 )
             }
         }
+        // This view owns the recorder, so it is responsible for releasing it.
+        // Releasing here (rather than relying on the view being deallocated) ensures the
+        // recorder resources are freed as soon as the screen goes away.
+        .onDisappear {
+            Task {
+                await recorder.release()
+            }
+        }
     }
 
     /// Avoid capturing `self` by copying the bindings, otherwise the recorder will leak.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6 - 2026-07-02]
+
+> ## ⚠️ BREAKING CHANGE — ACTION REQUIRED ⚠️
+>
+> **`AttendiMicrophone` no longer releases the recorder for you.**
+>
+> Previously, `AttendiMicrophoneViewModel` called `release()` on the recorder when it was
+> deallocated. As of this version it does not. If you upgrade **without updating your code**,
+> recorders passed to `AttendiMicrophone` will **never be released** and your app **will leak
+> memory, audio sessions, and threads**.
+>
+> **What you must do:** every object that creates a recorder must now call `release()` on it
+> when it is no longer needed (see the Migration Guide below). This applies to all recorders you
+> create with `AttendiRecorderFactory.create()`, whether or not they are used with
+> `AttendiMicrophone`.
+
+### Changed
+- Recorder resource ownership and cleanup responsibility has been moved to the object that creates the recorder instances.
+
+### Removed
+- Automatic recorder resource cleanup from `AttendiMicrophoneViewModel`. The component now only deactivates the plugins it added itself and no longer calls `release()` on the recorder.
+
+### Migration Guide
+- Ensure every object that owns a recorder explicitly calls `release()` on its recorder instances before they are deallocated.
+- For ViewModel-owned recorders, release from `deinit` (see `RecorderStreamingScreenViewModel`, `SoapScreenViewModel`, and `TwoMicrophonesStreamingScreenViewModel`).
+- For recorders owned directly by a SwiftUI `View`, release from `.onDisappear` (see `OneMicrophoneSyncScreenView`).
+
 ## [0.3.5 - 2026-02-05]
 ### Fixed
 - Memory leak caused by holding a strong reference inside `onStartCalled` and `onStopCalled` in `AttendiRecorderImpl` and by removing all the plugins on release.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,21 @@ private func onButtonPressed() {
         }
     }
 }
+
+private func releaseRecorder() {
+    Task {
+        await recorder.release()
+    }
+}
 ```
+
+#### Recorder Resource Ownership and Cleanup
+
+Recorder instances and their associated plugins should be released by the same object that creates and owns them. The `AttendiMicrophone` component does **not** release the recorder it is given — it only deactivates the plugins it added itself. Releasing the recorder is the responsibility of the owner (typically the screen or its ViewModel).
+
+In the examples, recorder cleanup is performed from the owner's `deinit` (for the ViewModel-based screens) so that resources are released when the screen is removed and its ViewModel is deallocated. This approach is used for simplicity in the sample implementation.
+
+If a screen owns the recorder directly in a SwiftUI `View` (without a ViewModel), release it from `.onDisappear`. Check `OneMicrophoneSyncScreenView` for this pattern.
 
 ### AttendiMicrophone
 A SwiftUI view designed for audio capture using a visual microphone button. It integrates with an `AttendiRecorder` instance and supports plugin-driven behavior, visual feedback, and customization of appearance and interaction.


### PR DESCRIPTION
Remove responsibility of releasing recorder resources from AttenidMicrophoneViewMode

## Checklist
- [X] Title follows Conventional Commits
- [X] Lint & tests pass locally
- [X] Docs updated (if needed)
- [ ] Linked to an open issue

## Description
- Remove responsibility of releasing recorder resources from AttendiMicrophoneViewModel.
- Update example screens.
   - OneMicrophoneSyncScreenView handle recorder lifecycle entirely in the view scope.

