### PR TITLE
fix(async-transcribe): prevent crash when replace_text indices are out of bounds

### DIFF
--- a/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/Model/TranscribeAsyncReplaceTextParameters.swift
+++ b/AttendiSpeechService/AttendiSpeechService/Services/AsyncTranscribe/Model/TranscribeAsyncReplaceTextParameters.swift
@@ -17,18 +17,37 @@ public struct TranscribeAsyncReplaceTextParameters: Equatable {
     }
 }
 
+/// Errors thrown by `TranscribeAsyncReplaceTextMapper`.
+public enum TranscribeAsyncReplaceTextError: Error, Equatable {
+    /// The start or end index exceeds the length of the string or falls on an invalid character boundary.
+    case indexOutOfBounds(startCharacterIndex: Int, endCharacterIndex: Int, textLength: Int)
+}
+
 public enum TranscribeAsyncReplaceTextMapper {
 
     /// Replaces a portion of the text between the given indices with new content.
     ///
     /// - Parameters:
     ///   - original: The original string.
-    ///   - action: The replace text action containing indices and replacement text.
+    ///   - params: The replace text parameters containing indices and replacement text.
     /// - Returns: A new string with the specified range replaced.
-    /// - Throws: An error if the indices are out of bounds.
+    /// - Throws: `TranscribeAsyncReplaceTextError.indexOutOfBounds` if either index exceeds the string length or falls on an invalid character boundary.
     public static func map(original: String, params: TranscribeAsyncReplaceTextParameters) throws -> String {
-        let startIndex = original.index(original.startIndex, offsetBy: params.startCharacterIndex)
-        let endIndex = original.index(original.startIndex, offsetBy: params.endCharacterIndex)
+        // The backend sends indices counted in UTF-16 code units, so we index
+        // via the utf16 view to stay in sync with the server's character offsets.
+        let utf16 = original.utf16
+        guard
+            let startUTF16Index = utf16.index(utf16.startIndex, offsetBy: params.startCharacterIndex, limitedBy: utf16.endIndex),
+            let endUTF16Index = utf16.index(utf16.startIndex, offsetBy: params.endCharacterIndex, limitedBy: utf16.endIndex),
+            let startIndex = startUTF16Index.samePosition(in: original),
+            let endIndex = endUTF16Index.samePosition(in: original)
+        else {
+            throw TranscribeAsyncReplaceTextError.indexOutOfBounds(
+                startCharacterIndex: params.startCharacterIndex,
+                endCharacterIndex: params.endCharacterIndex,
+                textLength: utf16.count
+            )
+        }
 
         return String(original[..<startIndex]) + params.text + String(original[endIndex...])
     }

--- a/AttendiSpeechService/AttendiSpeechServiceTests/AsyncTranscribePlugin/Mapper/TranscribeAsyncReplaceTextMapperTests.swift
+++ b/AttendiSpeechService/AttendiSpeechServiceTests/AsyncTranscribePlugin/Mapper/TranscribeAsyncReplaceTextMapperTests.swift
@@ -1,0 +1,75 @@
+import Testing
+@testable import AttendiSpeechService
+
+struct TranscribeAsyncReplaceTextMapperTests {
+
+    // MARK: - Replacing text
+
+    @Test
+    func map_withASCIIText_replacesCorrectRange() throws {
+        let params = TranscribeAsyncReplaceTextParameters(
+            text: "there",
+            startCharacterIndex: 6,
+            endCharacterIndex: 11
+        )
+        let result = try TranscribeAsyncReplaceTextMapper.map(original: "hello world", params: params)
+        #expect(result == "hello there")
+    }
+
+    @Test
+    func map_withPrecomposedAccentedCharacter_replacesCorrectRange() throws {
+        // Precomposed "é" (U+00E9) is 1 UTF-16 unit and 1 Swift Character — counts agree.
+        let original = "caf\u{00E9}"  // "café" — 4 UTF-16 units, 4 Swift characters
+        let params = TranscribeAsyncReplaceTextParameters(
+            text: "coffee",
+            startCharacterIndex: 0,
+            endCharacterIndex: 4
+        )
+        let result = try TranscribeAsyncReplaceTextMapper.map(original: original, params: params)
+        #expect(result == "coffee")
+    }
+
+    @Test
+    func map_withDecomposedAccentedCharacter_replacesCorrectRange() throws {
+        // Decomposed "é" (e + U+0301) is 2 UTF-16 units but 1 Swift Character.
+        // The backend sends UTF-16 indices, so endCharacterIndex: 5 correctly covers
+        // the full string even though Swift's character count is 4.
+        let original = "cafe\u{0301}"
+        #expect(original.utf16.count == 5)
+        #expect(original.count == 4)
+
+        let params = TranscribeAsyncReplaceTextParameters(
+            text: "coffee",
+            startCharacterIndex: 0,
+            endCharacterIndex: 5
+        )
+        let result = try TranscribeAsyncReplaceTextMapper.map(original: original, params: params)
+        #expect(result == "coffee")
+    }
+
+    // MARK: - Out of bounds indices
+
+    @Test
+    func map_whenStartIndexExceedsStringLength_throws() throws {
+        let params = TranscribeAsyncReplaceTextParameters(
+            text: "replacement",
+            startCharacterIndex: 10,
+            endCharacterIndex: 10
+        )
+        #expect(throws: TranscribeAsyncReplaceTextError.self) {
+            try TranscribeAsyncReplaceTextMapper.map(original: "hello", params: params)
+        }
+    }
+
+    @Test
+    func map_whenEndIndexExceedsStringLength_throws() throws {
+        let params = TranscribeAsyncReplaceTextParameters(
+            text: "replacement",
+            startCharacterIndex: 0,
+            endCharacterIndex: 10
+        )
+        #expect(throws: TranscribeAsyncReplaceTextError.self) {
+            try TranscribeAsyncReplaceTextMapper.map(original: "hello", params: params)
+        }
+    }
+}


### PR DESCRIPTION
## Checklist
- [x] Title follows Conventional Commits
- [x] Lint & tests pass locally
- [ ] Docs updated (if needed)
- [ ] Linked to an open issue

## Description
`TranscribeAsyncReplaceTextMapper.map` was calling `String.index(_:offsetBy:)` with indices provided by the backend. Swift counts characters as Unicode grapheme clusters, while the backend sends indices counted in UTF-16 code units. For plain ASCII these agree, but for characters like accented letters in decomposed form (NFD), the counts diverge — causing the index to exceed the string length and fatally crash the app.

The fix switches indexing to Swift's `utf16` view to stay in sync with the backend's offsets, and uses `index(_:offsetBy:limitedBy:)` with `samePosition(in:)` to throw a typed `TranscribeAsyncReplaceTextError.indexOutOfBounds` instead of crashing if the index is ever out of bounds or falls on an invalid character boundary.

A new `TranscribeAsyncReplaceTextMapperTests` suite has been added covering ASCII, precomposed and decomposed accented characters, and out-of-bounds indices.